### PR TITLE
🚑 FIX: 요청 이미지 용량 제한 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,10 @@ spring:
     hikari:
       data-source-properties:
         rewriteBatchedStatements: true
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 5MB
   jpa:
     defer-datasource-initialization: true
     show-sql: true


### PR DESCRIPTION
- 기존 1MB(defualt)에서 5MB로 수정

## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- `feature/13-picture`

### 💡 작업동기
- 요청 이미지의 용량 제한을 증가시킬 필요가 있습니다.

### 🔑 주요 변경사항
- 기존 1MB(`defualt`)에서 5MB로 수정

### 🏞 스크린샷
N/A

### 관련 이슈
- #13 